### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.26.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # Install the latest versions of our mods.  This is done as a separate step
 # so it will pull from an image cache if possible, unless there are changes.
 #
-FROM --platform=${BUILDPLATFORM} golang:1.21-alpine AS buildmod
+FROM --platform=${BUILDPLATFORM} golang:1.26-alpine AS buildmod
 RUN mkdir /build
 WORKDIR /build
 COPY go.mod .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opsmx/oes-birger
 
-go 1.21
+go 1.26.2
 
 require (
 	github.com/OpsMx/go-app-base v0.0.23


### PR DESCRIPTION
## Summary
- `go.mod`: `go 1.21` → `go 1.26.2`
- `Dockerfile`: `golang:1.21-alpine` → `golang:1.26-alpine`
- `.github/workflows/test.yml`: `go-version: [1.21.x]` → `[1.26.x]`

Verified locally on `go1.26.2 darwin/arm64`: `make test` green, `make local` builds all three binaries.

## Follow-up
A current `protoc-gen-go-grpc` generates stubs that use `grpc.ServerStreamingClient[T]` / `ServerStreamingServer[T]` generics, which require `google.golang.org/grpc` >= v1.62 (we're on v1.61.1). The committed `internal/tunnel/*.pb.go` files still work, but `make really-clean && make` on a modern toolchain will regenerate them and fail to build until grpc is bumped. Leaving that as a separate PR.

## Test plan
- [x] `make test` passes locally on Go 1.26.2
- [x] `make local` builds `bin/client`, `bin/server`, `bin/get-creds`