### PR TITLE
build: pin dev/proto tools in ./bin via install scripts

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint
@@ -13,8 +16,15 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26.x'
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Cache golangci-lint
+        uses: actions/cache@v5
         with:
-          version: latest
-          args: --timeout 5m
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-${{ hashFiles('scripts/install-dev-tools.sh') }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            golangci-lint-${{ hashFiles('scripts/install-dev-tools.sh') }}-
+            golangci-lint-
+      - name: Lint
+        run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -12,21 +15,13 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
     - name: Install Go
       uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/cache@v5
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Checkout code
-      uses: actions/checkout@v6
+        cache: true
+        cache-dependency-path: go.sum
     - name: Test
-      run: go test ./...
+      run: make test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,15 @@ All development goes through the `Makefile`.
 - `make images` — multi-arch Docker images via `docker buildx` (targets `agent-client-image`, `agent-controller-image` in the `Dockerfile`). Pushes by default.
 - `make clean` / `make really-clean` — the latter also removes generated `tunnel.pb.go` / `tunnel_grpc.pb.go`.
 
-**Protobuf prerequisites** (needed to regenerate stubs):
+**Protobuf prerequisites** — `protoc` itself is a system dependency (`brew install protobuf` / `apt install protobuf-compiler`). The Go plugins (`protoc-gen-go`, `protoc-gen-go-grpc`) are pinned in `scripts/install-proto-tools.sh` and installed into `./bin/` on demand:
 
 ```
-go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+./scripts/install-proto-tools.sh   # or: make generate
 ```
 
-Stubs live at `internal/tunnel/tunnel.pb.go` and `internal/tunnel/tunnel_grpc.pb.go`; the Makefile rebuilds them from `internal/tunnel/tunnel.proto` when needed. The `make local` / `make test` targets touch these automatically — if you edit the `.proto`, run `make really-clean` to force regeneration.
+Stubs live at `internal/tunnel/tunnel.pb.go` and `internal/tunnel/tunnel_grpc.pb.go` and are committed. Run `make generate` after editing `internal/tunnel/tunnel.proto` to regenerate them (the target installs the pinned plugins first if missing). `make really-clean` removes the stubs if you want to force regeneration.
+
+**Dev tools** — `golangci-lint` is pinned in `scripts/install-dev-tools.sh` and lands in `./bin/`. `make lint` installs it on demand and runs it; CI uses the same path so local and CI agree on the version.
 
 ### Running a single test
 
@@ -27,7 +28,7 @@ Standard Go invocation, e.g. `go test -race -run TestFoo ./internal/serviceconfi
 
 ### Lint
 
-CI runs `golangci-lint` (`.github/workflows/golangci-lint.yml`, `--timeout 5m`). There is no repo-local config; it uses the default ruleset. Run locally with `golangci-lint run ./...`.
+CI runs `make lint` (`.github/workflows/golangci-lint.yml`), which uses the pinned `golangci-lint` from `./bin/` (see `scripts/install-dev-tools.sh`). There is no repo-local config; it uses the default ruleset with `--timeout 5m`. Run locally with `make lint`.
 
 ### Local end-to-end
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,35 @@ now := $(shell date -u +%Y%m%dT%H%M%S)
 all: ${TARGETS}
 
 #
+# Help target - list the common entry points.
+#
+.PHONY: help
+help:
+	@echo "oes-birger Makefile targets"
+	@echo "==========================="
+	@echo ""
+	@echo "Building:"
+	@echo "  make              - Run tests and build binaries (default)"
+	@echo "  make local        - Build binaries into ./bin"
+	@echo "  make images       - Build and push multi-arch Docker images"
+	@echo ""
+	@echo "Testing / quality:"
+	@echo "  make test         - go test -race ./..."
+	@echo "  make lint         - Run pinned golangci-lint"
+	@echo "  make fmt          - gofmt -s -w ."
+	@echo ""
+	@echo "Code generation:"
+	@echo "  make generate     - Install pinned protoc plugins and regenerate .pb.go"
+	@echo ""
+	@echo "Tool installation (also invoked on demand):"
+	@echo "  ./scripts/install-proto-tools.sh  - protoc-gen-go, protoc-gen-go-grpc"
+	@echo "  ./scripts/install-dev-tools.sh    - golangci-lint"
+	@echo ""
+	@echo "Cleanup:"
+	@echo "  make clean        - Remove bin/ and build timestamps"
+	@echo "  make really-clean - Also remove generated .pb.go files"
+
+#
 # make a buildtime directory to hold the build timestamp files
 buildtime:
 	[ ! -d buildtime ] && mkdir buildtime
@@ -63,15 +92,32 @@ set-git-info:
 	@$(eval GIT_HASH=$(shell git rev-parse ${GIT_BRANCH}))
 
 #
-# Common components, like GRPC client code generation.
+# Local development tooling.  Versions are pinned in the install scripts and
+# everything lands in ./bin so builds stay reproducible across machines and CI.
 #
 
-internal/tunnel/tunnel.pb.go: go.mod internal/tunnel/tunnel.proto
-	protoc --go_out=. \
+bin/protoc-gen-go bin/protoc-gen-go-grpc:
+	./scripts/install-proto-tools.sh
+
+bin/golangci-lint:
+	./scripts/install-dev-tools.sh
+
+#
+# Common components, like GRPC client code generation.  The generated files
+# are committed, so CI and plain `make test` never need protoc; only the
+# explicit `make generate` path installs the pinned plugins and regenerates.
+#
+
+.PHONY: generate
+generate: bin/protoc-gen-go bin/protoc-gen-go-grpc
+	PATH="$(CURDIR)/bin:$$PATH" protoc --go_out=. \
 		--go_opt=paths=source_relative \
 		--go-grpc_out=. \
 		--go-grpc_opt=paths=source_relative \
 		internal/tunnel/tunnel.proto
+
+internal/tunnel/tunnel.pb.go: go.mod internal/tunnel/tunnel.proto
+	$(MAKE) generate
 
 #
 # Build locally, mostly for development speed.
@@ -80,11 +126,11 @@ internal/tunnel/tunnel.pb.go: go.mod internal/tunnel/tunnel.proto
 .PHONY: local
 local: $(addprefix bin/,$(BINARIES))
 
-bin/%:: set-git-info ${all_deps}
+$(addprefix bin/,$(BINARIES)): bin/%: set-git-info ${all_deps}
 	@[ -d bin ] || mkdir bin
 	go build -o $@ \
 		-ldflags="-X 'github.com/OpsMx/go-app-base/version.buildType=dev' -X 'github.com/OpsMx/go-app-base/version.gitHash=${GIT_HASH}' -X 'github.com/OpsMx/go-app-base/version.gitBranch=${GIT_BRANCH}'" \
-		app/$(@F)/*.go
+		app/$*/*.go
 
 #
 # Multi-architecture image builds
@@ -118,6 +164,20 @@ image-names:
 .PHONY: test
 test: ${pb_deps}
 	go test -race ./...
+
+#
+# Lint target - uses the pinned golangci-lint from ./bin.
+#
+.PHONY: lint
+lint: bin/golangci-lint
+	./bin/golangci-lint run --timeout 5m ./...
+
+#
+# Format target.
+#
+.PHONY: fmt
+fmt:
+	gofmt -s -w .
 
 #
 # Clean the world.

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2026 OpsMx, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+# Dev tool versions - update these to change versions across the project.
+GOLANGCI_LINT_VERSION="v2.4.0"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BIN_DIR="$PROJECT_ROOT/bin"
+
+echo "Installing development tools to $BIN_DIR..."
+mkdir -p "$BIN_DIR"
+
+GOBIN="$BIN_DIR" go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$GOLANGCI_LINT_VERSION"
+
+echo "Development tools installed successfully:"
+echo "  golangci-lint: $GOLANGCI_LINT_VERSION"

--- a/scripts/install-proto-tools.sh
+++ b/scripts/install-proto-tools.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright 2026 OpsMx, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+# Proto tool versions - update these to change versions across the project.
+PROTOC_GEN_GO_VERSION="v1.36.11"
+PROTOC_GEN_GO_GRPC_VERSION="v1.6.0"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BIN_DIR="$PROJECT_ROOT/bin"
+
+echo "Installing protobuf tools to $BIN_DIR..."
+mkdir -p "$BIN_DIR"
+
+GOBIN="$BIN_DIR" go install "google.golang.org/protobuf/cmd/protoc-gen-go@$PROTOC_GEN_GO_VERSION"
+GOBIN="$BIN_DIR" go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc@$PROTOC_GEN_GO_GRPC_VERSION"
+
+echo "Protobuf tools installed successfully:"
+echo "  protoc-gen-go:      $PROTOC_GEN_GO_VERSION"
+echo "  protoc-gen-go-grpc: $PROTOC_GEN_GO_GRPC_VERSION"
+echo
+echo "Note: 'protoc' itself is not a Go tool and must be installed separately"
+echo "      (e.g., 'brew install protobuf' or 'apt-get install -y protobuf-compiler')."


### PR DESCRIPTION
## Summary

Adopts the same local-tools pattern used in [cardinalhq/lakerunner](https://github.com/cardinalhq/lakerunner): versioned install scripts under `scripts/` drop pinned tool binaries into `./bin/`, and both the Makefile and CI call those pinned binaries so local and CI toolchains stay in lockstep.

- `scripts/install-proto-tools.sh` — pins `protoc-gen-go` (v1.36.11) and `protoc-gen-go-grpc` (v1.6.0)
- `scripts/install-dev-tools.sh` — pins `golangci-lint` (v2.4.0)
- `Makefile` — adds `make generate`, `make lint`, `make fmt`, `make help`; proto regeneration invokes the install script and prepends `./bin` to `PATH` so `protoc` finds the pinned plugins
- `.github/workflows/test.yml` — now runs `make test` (picks up `-race` from the Makefile) and uses `setup-go`'s built-in module cache
- `.github/workflows/golangci-lint.yml` — drops `golangci-lint-action@v9` with `version: latest` in favour of `make lint`, so CI uses the pinned version and caches the `~/.cache/golangci-lint` directory keyed on the install script + go.sum
- `CLAUDE.md` — updated proto/lint instructions to match

Release (`build-docker-images.yml`) is untouched — a follow-up issue will cover a larger modernization (goreleaser, dropping `::set-output`, etc.).

## Test plan

- [x] `make test` passes locally (`go test -race ./...`, 0 failures)
- [x] `make local` produces `bin/client`, `bin/server`, `bin/get-creds`
- [x] `make lint` installs `bin/golangci-lint` v2.4.0 and reports `0 issues.`
- [x] `./scripts/install-proto-tools.sh` installs `bin/protoc-gen-go` / `bin/protoc-gen-go-grpc` and `make generate` reproduces the committed `.pb.go` files byte-for-byte
- [ ] CI: Test + golangci-lint workflows pass on this branch