### PR TITLE
ci: add Woodpecker pipelines mirroring multirepo-mcp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Dependency directories
 # vendor/
 bin
+dist
 minica
 .DS_Store
 buildtime

--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -1,0 +1,41 @@
+when:
+  - event: push
+    branch: main
+
+steps:
+  - name: build
+    image: golang:1.26
+    commands:
+      - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o dist/agent-client ./app/client
+      - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o dist/agent-controller ./app/server
+      - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o dist/get-creds ./app/get-creds
+
+  - name: publish-agent-client
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: docker.flame.org/library/agent-client
+      registry: docker.flame.org
+      dockerfile: Dockerfile.agent-client.ci
+      tags: latest
+      platforms: linux/amd64
+      ipv6: true
+      buildkit_driveropt: network=host
+      username:
+        from_secret: docker_flame_org_username
+      password:
+        from_secret: docker_flame_org_password
+
+  - name: publish-agent-controller
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: docker.flame.org/library/agent-controller
+      registry: docker.flame.org
+      dockerfile: Dockerfile.agent-controller.ci
+      tags: latest
+      platforms: linux/amd64
+      ipv6: true
+      buildkit_driveropt: network=host
+      username:
+        from_secret: docker_flame_org_username
+      password:
+        from_secret: docker_flame_org_password

--- a/.woodpecker/test.yaml
+++ b/.woodpecker/test.yaml
@@ -1,0 +1,9 @@
+when:
+  - event: pull_request
+
+steps:
+  - name: test
+    image: golang:1.26
+    commands:
+      - make test
+      - make lint

--- a/Dockerfile.agent-client.ci
+++ b/Dockerfile.agent-client.ci
@@ -1,0 +1,30 @@
+#
+# Copyright 2026 OpsMx, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM alpine:3
+
+RUN apk update && apk upgrade --no-cache && apk add --no-cache ca-certificates curl
+RUN update-ca-certificates ; exit 0
+RUN mkdir /local /local/ca-certificates && rm -rf /usr/local/share/ca-certificates && ln -s /local/ca-certificates /usr/local/share/ca-certificates
+
+WORKDIR /app
+COPY docker/run.sh /app/run.sh
+COPY dist/agent-client /app/agent-client
+
+EXPOSE 9102
+
+ENTRYPOINT ["/bin/sh", "/app/run.sh"]
+CMD ["/app/agent-client"]

--- a/Dockerfile.agent-controller.ci
+++ b/Dockerfile.agent-controller.ci
@@ -1,0 +1,31 @@
+#
+# Copyright 2026 OpsMx, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM alpine:3
+
+RUN apk update && apk upgrade --no-cache && apk add --no-cache ca-certificates curl
+RUN update-ca-certificates ; exit 0
+RUN mkdir /local /local/ca-certificates && rm -rf /usr/local/share/ca-certificates && ln -s /local/ca-certificates /usr/local/share/ca-certificates
+
+WORKDIR /app
+COPY docker/run.sh /app/run.sh
+COPY dist/agent-controller /app/agent-controller
+COPY dist/get-creds /app/get-creds
+
+EXPOSE 9001-9002 9102
+
+ENTRYPOINT ["/bin/sh", "/app/run.sh"]
+CMD ["/app/agent-controller"]


### PR DESCRIPTION
## Summary

Adds a Woodpecker CI setup to this fork, mirroring the pattern used in `multirepo-mcp`. Additive — leaves the existing `.github/workflows/*` and the multi-stage `Dockerfile` untouched.

- `.woodpecker/test.yaml` — on `pull_request`: `make test && make lint` in `golang:1.26`.
- `.woodpecker/build.yaml` — on push to `main`: builds the three binaries to `dist/`, then publishes the `agent-client` and `agent-controller` images via `woodpeckerci/plugin-docker-buildx` to `docker.flame.org/library/`, using the `docker_flame_org_username` / `docker_flame_org_password` secrets.
- `Dockerfile.agent-client.ci` / `Dockerfile.agent-controller.ci` — thin Alpine images that consume the prebuilt binaries from `dist/`. Preserves the existing `docker/run.sh` entrypoint and the `/local/ca-certificates` layout from the multi-stage `Dockerfile`.
- `.gitignore` — ignores `dist/`.

## Deviations from `multirepo-mcp` (intentional)

- Two images (`agent-client`, `agent-controller`), so two `Dockerfile.*.ci` and two publish steps in a single `build.yaml` (matches how multirepo-mcp separates publishes within `build.yaml`).
- Test step uses `make test && make lint` (since #11 just landed pinned `make lint` via `./bin/`), instead of the reference's `make check` + ad-hoc `go install`.
- `platforms: linux/amd64` only, matching the reference. The existing GitHub Actions release path (`build-docker-images.yml`) still produces multi-arch via `make images` on tags.

## Relation to #12

#12 proposes replacing `make images` with goreleaser. This PR doesn't conflict — it's a separate pipeline targeting a different registry — but the goreleaser proposal may want a follow-up to decide which path is the canonical release flow.

## Test plan

- [ ] Configure `docker_flame_org_username` / `docker_flame_org_password` secrets in the Woodpecker org/repo settings.
- [ ] Open this PR and confirm `.woodpecker/test.yaml` runs `make test && make lint` cleanly.
- [ ] After merge, confirm `build.yaml` publishes `docker.flame.org/library/agent-client:latest` and `docker.flame.org/library/agent-controller:latest`.